### PR TITLE
Fix/support padding and spacing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.js text eol=lf
+*.ts text eol=lf
+*.md text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
-*.gitattributes text eol=lf
 *.css text eol=lf
 *.eslintrc text eol=lf
+*.gitattributes text eol=lf
 *.gitignore text eol=lf
 *.js text eol=lf
 *.js text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,16 @@
+*.gitattributes text eol=lf
+*.css text eol=lf
+*.eslintrc text eol=lf
+*.gitignore text eol=lf
 *.js text eol=lf
-*.ts text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.ldtk text eol=lf
 *.md text eol=lf
+*.md text eol=lf
+*.mustache text eol=lf
+*.svg text eol=lf
+*.ts text eol=lf
+*.ts text eol=lf
+*.txt text eol=lf
+*.yaml text eol=lf

--- a/api/functions/getWorld.ts
+++ b/api/functions/getWorld.ts
@@ -77,6 +77,7 @@ export const getWorld = (): World => {
                   ldtkGridTile: LDTK["levels"][0]["layerInstances"][0]["gridTiles"][0],
                 ): Level["layers"][0]["tiles"][0] => ({
                   pixiSprite: new PixiSprite(),
+                  tileId: ldtkGridTile.t,
                   tilesetX: ldtkGridTile.src[0] / ldtkLayerInstance.__gridSize,
                   tilesetY: ldtkGridTile.src[1] / ldtkLayerInstance.__gridSize,
                   x: ldtkGridTile.px[0],
@@ -106,6 +107,9 @@ export const getWorld = (): World => {
     for (let y: number = 0; y < ldtkDefTileset.__cHei; y++) {
       for (let x: number = 0; x < ldtkDefTileset.__cWid; x++) {
         const id: number = y * ldtkDefTileset.__cWid + x;
+        const xSpacing: number = ldtkDefTileset.spacing * x;
+        const ySpacing: number = ldtkDefTileset.spacing * y;
+        const padding: number = ldtkDefTileset.padding * 2;
         const matchedCustomDatum: LDTKTileCustomData | null =
           ldtkDefTileset.customData.find(
             (customDatum: LDTKTileCustomData): boolean =>
@@ -123,8 +127,8 @@ export const getWorld = (): World => {
           texture: new Texture(
             getDefinable(ImageSource, imageSourceID).texture.baseTexture,
             new Rectangle(
-              x * ldtkDefTileset.tileGridSize,
-              y * ldtkDefTileset.tileGridSize,
+              x * ldtkDefTileset.tileGridSize + xSpacing + padding,
+              y * ldtkDefTileset.tileGridSize + ySpacing + padding,
               ldtkDefTileset.tileGridSize,
               ldtkDefTileset.tileGridSize,
             ),

--- a/api/functions/getWorld.ts
+++ b/api/functions/getWorld.ts
@@ -77,7 +77,7 @@ export const getWorld = (): World => {
                   ldtkGridTile: LDTK["levels"][0]["layerInstances"][0]["gridTiles"][0],
                 ): Level["layers"][0]["tiles"][0] => ({
                   pixiSprite: new PixiSprite(),
-                  tileId: ldtkGridTile.t,
+                  tileID: ldtkGridTile.t,
                   tilesetX: ldtkGridTile.src[0] / ldtkLayerInstance.__gridSize,
                   tilesetY: ldtkGridTile.src[1] / ldtkLayerInstance.__gridSize,
                   x: ldtkGridTile.px[0],

--- a/api/functions/getWorld.ts
+++ b/api/functions/getWorld.ts
@@ -109,7 +109,6 @@ export const getWorld = (): World => {
         const id: number = y * ldtkDefTileset.__cWid + x;
         const xSpacing: number = ldtkDefTileset.spacing * x;
         const ySpacing: number = ldtkDefTileset.spacing * y;
-        const padding: number = ldtkDefTileset.padding * 2;
         const matchedCustomDatum: LDTKTileCustomData | null =
           ldtkDefTileset.customData.find(
             (customDatum: LDTKTileCustomData): boolean =>
@@ -127,8 +126,12 @@ export const getWorld = (): World => {
           texture: new Texture(
             getDefinable(ImageSource, imageSourceID).texture.baseTexture,
             new Rectangle(
-              x * ldtkDefTileset.tileGridSize + xSpacing + padding,
-              y * ldtkDefTileset.tileGridSize + ySpacing + padding,
+              x * ldtkDefTileset.tileGridSize +
+                xSpacing +
+                ldtkDefTileset.padding,
+              y * ldtkDefTileset.tileGridSize +
+                ySpacing +
+                ldtkDefTileset.padding,
               ldtkDefTileset.tileGridSize,
               ldtkDefTileset.tileGridSize,
             ),

--- a/api/functions/render.ts
+++ b/api/functions/render.ts
@@ -108,11 +108,7 @@ export const render = (): void => {
               x < state.values.config.width &&
               y < state.values.config.height
             ) {
-              const matchedTile: WorldTilesetTile =
-                tileset.tiles[
-                  tile.tilesetX +
-                    tile.tilesetY * (tileset.width / tileset.tileSize)
-                ];
+              const matchedTile: WorldTilesetTile = tileset.tiles[tile.tileId];
               tile.pixiSprite.texture = matchedTile.texture;
               tile.pixiSprite.x = x;
               tile.pixiSprite.y = y;

--- a/api/functions/render.ts
+++ b/api/functions/render.ts
@@ -108,7 +108,7 @@ export const render = (): void => {
               x < state.values.config.width &&
               y < state.values.config.height
             ) {
-              const matchedTile: WorldTilesetTile = tileset.tiles[tile.tileId];
+              const matchedTile: WorldTilesetTile = tileset.tiles[tile.tileID];
               tile.pixiSprite.texture = matchedTile.texture;
               tile.pixiSprite.x = x;
               tile.pixiSprite.y = y;

--- a/api/types/LDTK.ts
+++ b/api/types/LDTK.ts
@@ -9,12 +9,12 @@ export interface LDTK {
       readonly __cWid: number;
       readonly customData: LDTKTileCustomData[];
       readonly identifier: string;
+      readonly padding: number;
       readonly pxHei: number;
       readonly pxWid: number;
       readonly relPath: string;
-      readonly tileGridSize: number;
       readonly spacing: number;
-      readonly padding: number;
+      readonly tileGridSize: number;
       readonly uid: number;
     }[];
   };

--- a/api/types/LDTK.ts
+++ b/api/types/LDTK.ts
@@ -13,6 +13,8 @@ export interface LDTK {
       readonly pxWid: number;
       readonly relPath: string;
       readonly tileGridSize: number;
+      readonly spacing: number;
+      readonly padding: number;
       readonly uid: number;
     }[];
   };

--- a/api/types/World.ts
+++ b/api/types/World.ts
@@ -76,6 +76,7 @@ export interface Layer {
     readonly pixiSprite: PixiSprite;
     readonly tilesetX: number;
     readonly tilesetY: number;
+    readonly tileId: number;
     readonly x: number;
     readonly y: number;
   }[];

--- a/api/types/World.ts
+++ b/api/types/World.ts
@@ -76,7 +76,7 @@ export interface Layer {
     readonly pixiSprite: PixiSprite;
     readonly tilesetX: number;
     readonly tilesetY: number;
-    readonly tileId: number;
+    readonly tileID: number;
     readonly x: number;
     readonly y: number;
   }[];


### PR DESCRIPTION
Add support for Padding and Spacing.
this was tested using one of the Kenny tiny battle tile sets, I modified it to add padding.

Along the way, It was beneficial to change to using the LDTK tileIds over the calculated ones.
ldtkgridtile.t, according to https://ldtk.io/json/#ldtk-Tile, is the tile id.
